### PR TITLE
Make ignore paths to match exactly

### DIFF
--- a/src/Owin.StatelessAuth.Tests/StatelessAuthTests.cs
+++ b/src/Owin.StatelessAuth.Tests/StatelessAuthTests.cs
@@ -46,9 +46,10 @@
         {
             //Given
             var owinhttps = GetStatelessAuth(GetNextFunc(), statelessAuthOptions: new StatelessAuthOptions() { IgnorePaths = new List<string>() { "/" } });
+            var owinhttps = GetStatelessAuth(GetNextFunc(), statelessAuthOptions: new StatelessAuthOptions() { IgnorePaths = new List<string>() { "/" } } );
             var environment = new Dictionary<string, object>
             {
-                {"owin.RequestHeaders", new Dictionary<string, string[]>() {{"Authorization", new[] {"mysecuretoken"}}}},
+                {"owin.RequestHeaders", new Dictionary<string, string[]>() },
                 {"owin.RequestPath", "/"}
             };
 
@@ -58,7 +59,26 @@
             //Then
             Assert.Equal(true, task.IsCompleted);
             Assert.Equal(123, ((Task<int>)task).Result);
+        }
 
+
+        [Fact]
+        public void Should_Return_401_If_Misses_Ignore_Path()
+        {
+            //Given
+            var owinhttps = GetStatelessAuth(GetNextFunc(), statelessAuthOptions: new StatelessAuthOptions() { IgnorePaths = new List<string>() { "/" } });
+            var environment = new Dictionary<string, object>
+            {
+                {"owin.RequestHeaders", new Dictionary<string, string[]>() },
+                {"owin.RequestPath", "/authentic"}
+            };
+
+            //When
+            var task = owinhttps.Invoke(environment);
+
+            //Then
+            Assert.Equal(true, task.IsCompleted);
+            Assert.Equal(401, environment["owin.ResponseStatusCode"]);
         }
 
         [Fact]

--- a/src/Owin.StatelessAuth.Tests/StatelessAuthTests.cs
+++ b/src/Owin.StatelessAuth.Tests/StatelessAuthTests.cs
@@ -46,7 +46,6 @@
         {
             //Given
             var owinhttps = GetStatelessAuth(GetNextFunc(), statelessAuthOptions: new StatelessAuthOptions() { IgnorePaths = new List<string>() { "/" } });
-            var owinhttps = GetStatelessAuth(GetNextFunc(), statelessAuthOptions: new StatelessAuthOptions() { IgnorePaths = new List<string>() { "/" } } );
             var environment = new Dictionary<string, object>
             {
                 {"owin.RequestHeaders", new Dictionary<string, string[]>() },

--- a/src/Owin.StatelessAuth/StatelessAuth.cs
+++ b/src/Owin.StatelessAuth/StatelessAuth.cs
@@ -28,7 +28,7 @@
 
             var path = (string)environment["owin.RequestPath"];
 
-            if (statelessAuthOptions != null && statelessAuthOptions.IgnorePaths.Any(x => path.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0))
+            if (statelessAuthOptions != null && statelessAuthOptions.IgnorePaths.Any(x => path.Equals(x, StringComparison.OrdinalIgnoreCase)))
             {
                 return nextFunc(environment);
             }


### PR DESCRIPTION
I'm not convinced the current strategy for matching ignore paths makes sense? It seems a little dangerous to apply using any substring of the input url. 

Also, the current test for ignore paths doesn't actually test anything as the test still passes without IgnorePaths being set.

This pull request attempts to address this.
