### PR TITLE
Add support for passthrough

### DIFF
--- a/src/Owin.StatelessAuth/StatelessAuthOptions.cs
+++ b/src/Owin.StatelessAuth/StatelessAuthOptions.cs
@@ -6,5 +6,6 @@
     {
         public IEnumerable<string> IgnorePaths { get; set; }
         public string WWWAuthenticateChallenge { get; set; }
+        public bool PassThroughUnauthorizedRequests { get; set; }
     }
 }


### PR DESCRIPTION
Added an option to pass through requests to other authentication middleware if unable to verify the request.